### PR TITLE
Tweaks and `export` builtin

### DIFF
--- a/example/pts-socket.js
+++ b/example/pts-socket.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var bash = require('../');
-var spawn = require('pty.js').spawn
+var spawn = require('pty.js').spawn;
 var clone = require('clone');
 var duplexer = require('duplexer');
 var ReadStream = require('tty').ReadStream;
@@ -15,5 +15,7 @@ var sh = bash({
     exists: fs.exists
 });
 
-var s = sh.createStream();
-process.stdin.pipe(s).pipe(process.stdout);
+require('net').createServer(function (sock) {
+  var s = sh.createStream();
+  sock.pipe(s).pipe(sock)
+}).listen(7777)

--- a/example/pts.js
+++ b/example/pts.js
@@ -15,5 +15,16 @@ var sh = bash({
     exists: fs.exists
 });
 
+sh.on('exit', process.exit);
+
+process.stdin.on('data', function (buf) {
+    if (sh.current) { /* let the current program handle the input */ }
+    else if (buf[0] === 13) process.stdout.write('\n');
+    else if (buf[0] > 27 && buf[0] < 127) {
+        process.stdout.write(buf);
+    }
+});
+process.stdin.setRawMode(true);
+
 var s = sh.createStream();
 process.stdin.pipe(s).pipe(process.stdout);

--- a/index.js
+++ b/index.js
@@ -522,7 +522,9 @@ Bash.prototype.eval = function (line) {
         return p;
     }
     
-    return duplexer(input, output);
+    var s = duplexer(input, output);
+    output.on('exit', function (c) { s.emit('exit', c) });
+    return s
 };
 
 function copy (obj) {

--- a/index.js
+++ b/index.js
@@ -387,8 +387,6 @@ Bash.prototype.eval = function (line) {
         }
     }
     
-    var index = 0;
-    
     (function run (prevCode) {
         self.env['?'] = prevCode;
         
@@ -399,6 +397,7 @@ Bash.prototype.eval = function (line) {
             });
         }
         var cmd = shiftCommand();
+        input.pipe(cmd);
         var redirected = false;
         
         while (commands[0] && /^[|<>]$/.test(commands[0].op)) {
@@ -520,7 +519,6 @@ Bash.prototype.eval = function (line) {
             p.queue(null);
         }
         
-        if (index++ === 0) input.pipe(p);
         return p;
     }
     

--- a/index.js
+++ b/index.js
@@ -275,10 +275,10 @@ Bash.prototype.createStream = function () {
     self.once('exit', end);
     
     var queue = [];
-    input.pipe(through(write, end));
+    input.pipe(through(evaluator, end));
     return duplexer(input, output);
     
-    function write (buf) {
+    function evaluator (buf) {
         var line = typeof buf === 'string' ? buf : buf.toString('utf8');
         if (line === '') {
             if (!closed) {
@@ -323,7 +323,7 @@ Bash.prototype.createStream = function () {
             nextTick(function () {
                 if (!closed) output.queue(self.getPrompt());
                 if (queue.length) {
-                    write(queue.shift());
+                    evaluator(queue.shift());
                 }
                 else if (closed) {
                     output.queue(null);

--- a/index.js
+++ b/index.js
@@ -216,6 +216,9 @@ Bash.prototype.createStream = function () {
                 return write(buf.slice(i + 1));
             }
             else if (c === 10 || c === 13) {
+                if (buf.substr(i, 2) === '\r\n') {
+                    i += 1;
+                }
                 this.queue(line);
                 if (line.length) {
                     self.history.push(line);

--- a/lib/builtins/export.js
+++ b/lib/builtins/export.js
@@ -1,0 +1,11 @@
+var resumerExit = require('../resumer_exit');
+
+module.exports = function (args) {
+    for (var i = 0, len = args.length; i < len; i++) {
+        var kv = args[i].split('=');
+        var k = kv.shift();
+        var v = kv.join('=');
+        this.env[k] = v;
+    }
+    return resumerExit(0);
+}

--- a/lib/builtins/index.js
+++ b/lib/builtins/index.js
@@ -4,3 +4,4 @@ exports.pwd = require('./pwd.js');
 exports.exit = require('./exit.js');
 exports['true'] = require('./true.js');
 exports['false'] = require('./false.js');
+exports['export'] = require('./export.js');

--- a/readme.markdown
+++ b/readme.markdown
@@ -59,10 +59,11 @@ var sh = bash({
     read: fs.createReadStream,
     exists: fs.exists
 });
-sh.on('close', process.exit);
+sh.on('exit', process.exit);
 
 process.stdin.on('data', function (buf) {
-    if (buf[0] === 13) process.stdout.write('\n');
+    if (sh.current) { /* let the current program handle the input */ }
+    else if (buf[0] === 13) process.stdout.write('\n');
     else if (buf[0] > 27 && buf[0] < 127) {
         process.stdout.write(buf);
     }


### PR DESCRIPTION
So here's a variety of tweaks and one new feature: the `export` builtin. It turns out most of the weirdness I was seeing with inputs had to do with local-echo being enabled in the pts example. I've fixed that and added the same fix to the example in readme.markdown
